### PR TITLE
Fix preg_replace

### DIFF
--- a/upload/admin/controller/common/security.php
+++ b/upload/admin/controller/common/security.php
@@ -282,7 +282,7 @@ class Security extends \Opencart\System\Engine\Controller {
 		}
 
 		if (isset($this->request->get['name'])) {
-			$name = preg_replace('[^a-zA-z0-9]', '', basename(html_entity_decode(trim((string)$this->request->get['name']), ENT_QUOTES, 'UTF-8')));
+			$name = preg_replace('/[^a-zA-Z0-9]/', '', basename(html_entity_decode(trim((string)$this->request->get['name']), ENT_QUOTES, 'UTF-8')));
 		} else {
 			$name = 'admin';
 		}


### PR DESCRIPTION
The regular expression '[^a-zA-z0-9]' needs to be replaced with '/[^a-zA-Z0-9]/' , that is, if not letter or digit.