### PR TITLE
Fix the repairCategories function.

### DIFF
--- a/upload/admin/model/catalog/category.php
+++ b/upload/admin/model/catalog/category.php
@@ -359,10 +359,10 @@ class Category extends \Opencart\System\Engine\Model {
 	 * $this->model_catalog_category->repairCategories();
 	 */
 	public function repairCategories(int $parent_id = 0): void {
-		$categories = $this->model_catalog_category->getCategories(['filter_parent_id' => $parent_id]);
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "category` WHERE `parent_id` = '" . (int)$parent_id . "'");
 
 		// Delete the path below the current one
-		foreach ($categories as $category) {
+		foreach ($query->rows as $category) {
 			// Delete the path below the current one
 			$this->model_catalog_category->deletePaths($category['category_id']);
 


### PR DESCRIPTION
If the 'oc_category_path' is empty or corrupted, the repairCategories may not always work. This proposed change addresses the issue where the 'oc_category_path' table was empty. It then completely repopulates this DB table.